### PR TITLE
Add ABN Amro specific import configuration

### DIFF
--- a/nl/abnamro/default.json
+++ b/nl/abnamro/default.json
@@ -1,0 +1,45 @@
+{
+    "file-type": "csv",
+    "date-format": "Ymd",
+    "has-headers": false,
+    "delimiter": "tab",
+    "apply-rules": true,
+    "specifics": {
+        "AbnAmroDescription": 1
+    },
+    "import-account": 1,
+    "column-count": 10,
+    "column-roles": [
+        "account-number",
+        "currency-code",
+        "date-transaction",
+        "_ignore",
+        "_ignore",
+        "date-interest",
+        "amount",
+        "description",
+        "opposing-name",
+        "opposing-iban"
+    ],
+    "column-do-mapping": [
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+    ],
+    "column-roles-complete": false,
+    "column-mapping-config": {
+        "0": [],
+        "1": {
+            "EUR": 1
+        },
+        "8": [],
+        "9": []
+    }
+}


### PR DESCRIPTION
This adds the configuration to parse the tab-delimited transaction history of ABN Amro Bank.