### PR TITLE
Add an import configuration the credit card from DKB (Deutsche Kreditbank)

### DIFF
--- a/de/dkb/csv-credit.json
+++ b/de/dkb/csv-credit.json
@@ -1,0 +1,26 @@
+{
+    "file-type": "csv",
+    "date-format": "d.m.Y",
+    "has-headers": true,
+    "delimiter": ";",
+    "apply-rules": true,
+    "specifics": [],
+    "import-account": 1,
+    "column-count": 6,
+    "column-roles": [
+        "_ignore",
+        "date-transaction",
+        "date-invoice",
+        "description",
+        "amount",
+        "_ignore"
+    ],
+    "column-do-mapping": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+    ]
+}


### PR DESCRIPTION
The exported file has obsolete information in the header before the actual data begins which has to be deleted by hand.
Further, the encoding of the exported file is ISO-8859-1 (latin1) and has to be converted to UTF-8.