### PR TITLE
Add Simplii Bank [Canada]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This repository contains standardized import configurations for Firefly III. Var
 * [Barclays](https://raw.githubusercontent.com/firefly-iii/import-configurations/master/gb/barclays/default.json)
 * [Lloyds](https://raw.githubusercontent.com/firefly-iii/import-configurations/master/gb/lloyds/default.json)
 
+### Canada
+* [Simplii](https://github.com/firefly-iii/import-configurations/blob/master/ca/simplii/default.json)
+
 ### The Netherlands
 * [Rabobank (new CSV)](https://github.com/firefly-iii/import-configurations/blob/master/nl/rabobank/rabobank-new-csv-format.json)
 * [ABN AMRO](https://github.com/firefly-iii/import-configurations/blob/master/nl/abnamro/default.json)

--- a/ca/simplii/default.json
+++ b/ca/simplii/default.json
@@ -1,0 +1,22 @@
+{
+    "file-type": "csv",
+    "date-format": "m\/d\/Y",
+    "has-headers": true,
+    "delimiter": ",",
+    "apply-rules": false,
+    "specifics": [],
+    "import-account": 1,
+    "column-count": 4,
+    "column-roles": [
+        "date-transaction",
+        "description",
+        "amount_credit",
+        "amount_debit"
+    ],
+    "column-do-mapping": [
+        false,
+        false,
+        false,
+        false
+    ]
+}


### PR DESCRIPTION
Adding simplii bank account for Canada. Works for importing transactions from chequing and savings accounts.