### PR TITLE
Fix simplii config

### DIFF
--- a/ca/simplii/default.json
+++ b/ca/simplii/default.json
@@ -10,8 +10,8 @@
     "column-roles": [
         "date-transaction",
         "description",
-        "amount_credit",
-        "amount_debit"
+        "amount_debit",
+        "amount_credit"
     ],
     "column-do-mapping": [
         false,


### PR DESCRIPTION
Had the credit and debit columns in the wrong order. Just discovered this when importing some transactions. Must have mixed up these config files when I was initially making them. I can confidently confirm that this one behaves as expected now.