### PR TITLE
column date-interest removed

### DIFF
--- a/ch/creditsuisse/default.json
+++ b/ch/creditsuisse/default.json
@@ -4,17 +4,15 @@
     "delimiter": ",",
     "import-account": 12,
     "specifics": [],
-    "column-count": 6,
+    "column-count": 5,
     "column-roles": [
         "date-transaction",
         "description",
         "amount_debit",
         "amount_credit",
-        "date-interest",
         "_ignore"
     ],
     "column-do-mapping": [
-        false,
         false,
         false,
         false,


### PR DESCRIPTION
The column `"date-interest",` has been removed in the csv by the bank