### PR TITLE
Add importer for Barclaycard Credit Card

### DIFF
--- a/gb/barclaycard/default.json
+++ b/gb/barclaycard/default.json
@@ -13,8 +13,8 @@
         "_ignore",
         "_ignore",
         "category-name",
-        "amount_credit",
-        "amount_debit"
+        "_ignore",
+        "amount"
     ],
     "column-do-mapping": [
         true,
@@ -22,7 +22,7 @@
         false,
         false,
         true,
-        true,
+        false,
         true
     ],
     "column-mapping-config": {

--- a/gb/barclaycard/default.json
+++ b/gb/barclaycard/default.json
@@ -1,0 +1,30 @@
+{
+    "file-type": "csv",
+    "date-format": "d M y",
+    "has-headers": false,
+    "delimiter": ",",
+    "apply-rules": false,
+    "specifics": [],
+    "import-account": 1,
+    "column-count": 7,
+    "column-roles": [
+        "date-transaction",
+        "description",
+        "_ignore",
+        "_ignore",
+        "category-name",
+        "amount_credit",
+        "amount_debit"
+    ],
+    "column-do-mapping": [
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true
+    ],
+    "column-mapping-config": {
+    }
+}


### PR DESCRIPTION
Note this is different from the Barclays importer which exists already.
Barclaycard is owned by Barclays but uses a separate website.