### PR TITLE
Changed ignore fields to actual fields for Argenta

### DIFF
--- a/be/argenta/default.json
+++ b/be/argenta/default.json
@@ -11,14 +11,14 @@
         "account-iban",
         "date-book",
         "date-process",
-        "_ignore",
-        "_ignore",
+        "external-id",
+        "description",
         "amount",
         "currency-code",
         "date-transaction",
         "opposing-iban",
         "opposing-name",
-        "description"
+        "note"
     ],
     "column-do-mapping": [
         false,


### PR DESCRIPTION
The fields that had _ignore in them actual represent field data that could be used.
And changed description into note.

RFC: https://github.com/firefly-iii/firefly-iii/issues/2992#issuecomment-573429810

Changes in this pull request:
- Changed `_ignore` on line 14 to the `external-id`
- Changed `_ignore` on line 15 to the `description`
- Changed `description` on line 21 to `note` since description is one line 15

@JC5
