### PR TITLE
add sepa mandate reference mapping to de/dkb/csv-giro.json

### DIFF
--- a/de/dkb/csv-giro.json
+++ b/de/dkb/csv-giro.json
@@ -17,7 +17,7 @@
         "opposing-bic",
         "amount",
         "sepa_ct_op",
-        "_ignore",
+        "sepa_db",
         "_ignore",
         "_ignore"
     ],


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:
- My dkb csv exports contain "Mandatsreferenz" as the 10th field, so I added it to the import config.
- I don't understand the naming "sepa_db", but this is the exported import config I get when I set the field to "SEPA Mandate Identifier".

@JC5
