### PR TITLE
Scotiabank Chequing

### DIFF
--- a/ca/Scotiabank
+++ b/ca/Scotiabank
@@ -1,0 +1,24 @@
+{
+    "file-type": "csv",
+    "date-format": "mm\/dd\/YYYY",
+    "has-headers": false,
+    "delimiter": ",",
+    "apply-rules": false,
+    "specifics": [],
+    "import-account": 5,
+    "column-count": 5,
+    "column-roles": [
+        "date-transaction",
+        "amount",
+        "_ignore",
+        "Description",
+        "Org Transit"
+    ],
+    "column-do-mapping": [
+        false,
+        false,
+        false,
+        false,
+        false
+    ]
+}


### PR DESCRIPTION
Each account type has a different default .csv format.
This is the standard chequing account
https://www1.scotiaconnect.scotiabank.com/help/secured/en_US/ScotiaConnect_Standard_Import_and_Export_Record_Layouts.pdf

Fixes issue # (if relevant)

Changes in this pull request:

- 
- 
- 

@JC5
