### PR TITLE
Add Santander and mBank configs

### DIFF
--- a/pl/mbank/default.json
+++ b/pl/mbank/default.json
@@ -1,0 +1,52 @@
+{
+    "date": "Y-m-d",
+    "default_account": 54,
+    "delimiter": "semicolon",
+    "headers": true,
+    "ignore_duplicate_lines": false,
+    "ignore_duplicate_transactions": true,
+    "rules": true,
+    "skip_form": false,
+    "add_import_tag": true,
+    "specifics": [],
+    "roles": [
+        "date_transaction",
+        "description",
+        "_ignore",
+        "category-name",
+        "amount",
+        "_ignore",
+        "_ignore"
+    ],
+    "do_mapping": {
+        "3": true,
+        "0": false,
+        "1": false,
+        "2": false,
+        "4": false,
+        "5": false,
+        "6": false
+    },
+    "mapping": {
+        "3": {
+            "Akcesoria i wyposa\u017cenie": 28,
+            "Bez kategorii": 19,
+            "Elektronika": 4,
+            "Jedzenie poza domem": 16,
+            "Multimedia, ksi\u0105\u017cki i prasa": 31,
+            "Odzie\u017c i obuwie": 18,
+            "Op\u0142aty i odsetki": 10,
+            "Osobiste - inne": 9,
+            "Paliwo": 12,
+            "Remont i ogr\u00f3d": 20,
+            "Sp\u0142ata karty kredytowej": 26,
+            "Ubezpieczenia": 7,
+            "Wp\u0142ywy - inne": 19,
+            "Wyj\u015bcia i wydarzenia": 5,
+            "Zdrowie i uroda": 13,
+            "Zwierz\u0119ta": 1,
+            "\u017bywno\u015b\u0107 i chemia domowa": 11
+        }
+    },
+    "version": 2
+}

--- a/pl/santander/default.json
+++ b/pl/santander/default.json
@@ -1,0 +1,35 @@
+{
+    "date": "d-m-Y",
+    "default_account": 11,
+    "delimiter": "comma",
+    "headers": true,
+    "ignore_duplicate_lines": false,
+    "ignore_duplicate_transactions": true,
+    "rules": false,
+    "skip_form": false,
+    "specifics": [],
+    "roles": [
+        "_ignore",
+        "date_transaction",
+        "description",
+        "opposing-name",
+        "opposing-iban",
+        "amount",
+        "_ignore",
+        "_ignore",
+        "_ignore"
+    ],
+    "do_mapping": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+    ],
+    "mapping": [],
+    "version": 2
+}


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Added configuration for importing Santander CSV export (works fine with company and private accounts ) and mBank but here some manual cleanup is needed  as mBank does not export it cleanly unfortunately :( 


@JC5
