### PR TITLE
Add N26 Bank Spain

### DIFF
--- a/es/n26/default.json
+++ b/es/n26/default.json
@@ -1,0 +1,32 @@
+{
+    "date": "Ymd",
+    "default_account": 1,
+    "delimiter": "comma",
+    "headers": true,
+    "ignore_duplicate_lines": true,
+    "ignore_duplicate_transactions": true,
+    "rules": true,
+    "skip_form": false,
+    "specifics": [],
+    "import-account": 1,
+    "column-count": 10,
+    "column-roles": [
+        "date",
+        "opposing-name",
+        "opposing-IBAN",
+        "tags",
+        "description",
+        "category-name",
+        "amount"
+    ],
+    "column-do-mapping": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+    ],
+    "version": 2
+}

--- a/es/n26/default.json
+++ b/es/n26/default.json
@@ -1,5 +1,5 @@
 {
-    "date": "Ymd",
+    "date": "Y-m-d",
     "default_account": 1,
     "delimiter": "comma",
     "headers": true,
@@ -7,19 +7,24 @@
     "ignore_duplicate_transactions": true,
     "rules": true,
     "skip_form": false,
+    "add_import_tag": true,
     "specifics": [],
-    "import-account": 1,
-    "column-count": 10,
-    "column-roles": [
-        "date",
+    "roles": [
+        "date_transaction",
         "opposing-name",
-        "opposing-IBAN",
-        "tags",
+        "opposing-iban",
+        "tags-comma",
         "description",
         "category-name",
-        "amount"
+        "amount",
+        "_ignore",
+        "_ignore",
+        "_ignore"
     ],
-    "column-do-mapping": [
+    "do_mapping": [
+        false,
+        false,
+        false,
         false,
         false,
         false,
@@ -28,5 +33,6 @@
         false,
         false
     ],
+    "mapping": [],
     "version": 2
 }


### PR DESCRIPTION
Changes in this pull request:

1. Created N26 Bank Spain. 

Parameter "ignore_duplicate_lines" set as FALSE, to avoid exclusion of identical transactions even in different dates (i.e.: money extractions of same amount)
Parameter "delimiter" set as "comma". Can easily be changed to "semicolon", depending on the region.

@JC5

