### PR TITLE
DKB Refresher

### DIFF
--- a/de/dkb/README.md
+++ b/de/dkb/README.md
@@ -10,6 +10,8 @@ There are a few things you have to be aware of while working with DKB and Firefl
 
 4. You should remove the fake transaction labelled `Abschluss`. It appears on the first of every month and only displays the current account balance. Because the format is not a valid transaction, the CSV importer will throw an error on this line. This is optional because the error does not do any harm besides showing up.
 
+5. You may wish to set `skip_form` to `true` in your local copy of the configurations to skip a few clicks. By default the form is presented so that you can double-check the configuration before you perform your first import.
+
 ## Automation
 
-If you wish to automate these steps, have a look at [Firefly III DKB CSV Fixer](https://github.com/MadWalnut/firefly-iii-dkb-csv-fix). It can apply all needed changes to your CSV file with single command or click.
+If you wish to automate steps 1-4, have a look at [Firefly III DKB CSV Fixer](https://github.com/MadWalnut/firefly-iii-dkb-csv-fix). It can apply all needed changes to your CSV file with a single command or click.

--- a/de/dkb/csv-credit.json
+++ b/de/dkb/csv-credit.json
@@ -1,26 +1,35 @@
 {
-    "file-type": "csv",
-    "date-format": "d.m.Y",
-    "has-headers": true,
-    "delimiter": ";",
-    "apply-rules": true,
+    "date": "d.m.Y",
+    "default_account": 1,
+    "delimiter": "semicolon",
+    "headers": true,
+    "rules": true,
+    "skip_form": false,
+    "add_import_tag": true,
     "specifics": [],
-    "import-account": 1,
-    "column-count": 6,
-    "column-roles": [
+    "roles": [
         "_ignore",
-        "date-transaction",
-        "date-invoice",
+        "date_transaction",
+        "date_invoice",
         "description",
         "amount",
+        "_ignore",
         "_ignore"
     ],
-    "column-do-mapping": [
+    "do_mapping": [
+        false,
         false,
         false,
         false,
         false,
         false,
         false
-    ]
+    ],
+    "mapping": [],
+    "duplicate_detection_method": "none",
+    "ignore_duplicate_lines": false,
+    "ignore_duplicate_transactions": false,
+    "unique_column_index": 0,
+    "unique_column_type": "internal_reference",
+    "version": 2
 }

--- a/de/dkb/csv-giro.json
+++ b/de/dkb/csv-giro.json
@@ -1,15 +1,15 @@
 {
-    "file-type": "csv",
-    "date-format": "d.m.Y",
-    "has-headers": true,
-    "delimiter": ";",
-    "apply-rules": true,
+    "date": "d.m.Y",
+    "default_account": 1,
+    "delimiter": "semicolon",
+    "headers": true,
+    "rules": true,
+    "skip_form": false,
+    "add_import_tag": true,
     "specifics": [],
-    "import-account": 1,
-    "column-count": 12,
-    "column-roles": [
-        "date-book",
-        "date-transaction",
+    "roles": [
+        "date_book",
+        "date_transaction",
         "note",
         "opposing-name",
         "description",
@@ -21,7 +21,7 @@
         "_ignore",
         "_ignore"
     ],
-    "column-do-mapping": [
+    "do_mapping": [
         false,
         false,
         false,
@@ -34,5 +34,12 @@
         false,
         false,
         false
-    ]
+    ],
+    "mapping": [],
+    "duplicate_detection_method": "none",
+    "ignore_duplicate_lines": false,
+    "ignore_duplicate_transactions": false,
+    "unique_column_index": 0,
+    "unique_column_type": "internal_reference",
+    "version": 2
 }


### PR DESCRIPTION
Changes in this pull request:

1. Update the configurations to match the most recent version of the CSV Importer tool
2. Slightly opinionated: Don't try to skip duplicates. DKB generally doesn't produce any. Have had trouble with duplicate detection skipping valid transactions (same day, amount, recipient), hence disabled.
3. Update the README with a hint about setting skip_form to true to save a few steps on future imports and fix a small typo

@JC5

