### PR TITLE
Update ANZ default.json

### DIFF
--- a/au/anz/default.json
+++ b/au/anz/default.json
@@ -1,9 +1,9 @@
 {
     "version": 3,
-    "source": "fidi-0.9.0",
-    "created_at": "2022-02-20T07:33:28+01:00",
-    "date": "d\/m\/Y",
-    "default_account": 0,
+    "source": "ff3-importer-1.3.9",
+    "created_at": "2023-11-08T15:46:56+01:00",
+    "date": "d\/n\/Y",
+    "default_account": 1,
     "delimiter": "comma",
     "headers": false,
     "rules": false,
@@ -12,9 +12,19 @@
     "roles": [
         "date_transaction",
         "amount",
-        "description"
+        "description",
+        "opposing-name",
+        "_ignore",
+        "_ignore",
+        "_ignore",
+        "_ignore"
     ],
     "do_mapping": [
+        false,
+        false,
+        false,
+        false,
+        false,
         false,
         false,
         false
@@ -22,16 +32,19 @@
     "mapping": [],
     "duplicate_detection_method": "classic",
     "ignore_duplicate_lines": true,
-    "ignore_duplicate_transactions": true,
     "unique_column_index": 0,
     "unique_column_type": "internal_reference",
-    "flow": "csv",
+    "flow": "file",
+    "content_type": "csv",
+    "custom_tag": "",
     "identifier": "0",
     "connection": "0",
     "ignore_spectre_categories": false,
+    "grouped_transaction_handling": "",
+    "use_entire_opposing_address": false,
     "map_all_data": false,
     "accounts": [],
-    "date_range": "all",
+    "date_range": "",
     "date_range_number": 30,
     "date_range_unit": "d",
     "date_not_before": "",
@@ -39,5 +52,7 @@
     "nordigen_country": "",
     "nordigen_bank": "",
     "nordigen_requisitions": [],
-    "conversion": false
+    "nordigen_max_days": "90",
+    "conversion": false,
+    "ignore_duplicate_transactions": true
 }


### PR DESCRIPTION
Updated Anz bank values to use correct date format and mapped another column from the csv.
Example date for Anz '13/9/2023'

Changes in this pull request:

1.  Updated date from d\/m\/Y to  d\/n\/Y
2. added role "opposing-name" to column 4
3. The rest of the changes were generated by saving the config with default values

@JC5

